### PR TITLE
set .build as the workflows repository for the GitHub App

### DIFF
--- a/organization-workflows-settings.yml
+++ b/organization-workflows-settings.yml
@@ -1,0 +1,6 @@
+workflows_repository: .build
+include_workflows_repository: false
+exclude:
+  repositories:
+  - '.admin'
+  - '.github'


### PR DESCRIPTION
This is basically saying to trigger the builds on the .build repo and which repos are not triggering builds. The configuration is taken by the GitHub App as described here: https://github.com/SvanBoxel/organization-workflows